### PR TITLE
What about using a map instead of a list?

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,16 +10,16 @@ app.set('port', process.env.PORT || 3001);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended:true }));
 app.use(express.static(__dirname + '/public'));
-app.locals.urls = [];
+app.locals.urls = {};
 
 app.get('/api/urls', (request, response) => {
-  response.send({ urls: app.locals.urls });
+  response.send({ urls: Object.values(app.locals.urls) });
 });
 
 app.get('/api/:shortid', (request, response) => {
   const { shortid } = request.params;
 
-  const url = app.locals.urls.filter(url => url.shortID === shortid)[0];
+  const url = app.locals.urls[shortid];
   if (url) {
     url.count++;
     return response.redirect(301, url.longUrl);
@@ -40,7 +40,7 @@ app.post('/api/post', (request, response) => {
   obj.longUrl = url;
   obj.count = 0;
 
-  app.locals.urls.push(obj);
+  app.locals.urls[obj.shortID] = obj;
   response.status(201).json(obj.shortID);
 });
 


### PR DESCRIPTION
Hey!

Since all the urls are keyed off of the `shortId`, why not make `app.locals.url` a map instead of a list? That way you don't have to iterate at all to find the url you're looking for.

(I didn't run the code, might not actually work 🎉)

I think our convo about indexing was in the context of storing the data in an actual db, instead of using `app.locals`. Serving millions of urls you'd probably want a [unique index](https://www.postgresql.org/docs/9.4/static/indexes-unique.html) on the `shortId` column so you're not doing a table scan every time you're looking up a url by its shortId. (The concept of indexes exists for relational and noSQL dbs, the implementation and side effects just vary, just a heads up).